### PR TITLE
Preserve escaped characters

### DIFF
--- a/setup_and_run.sh
+++ b/setup_and_run.sh
@@ -6,7 +6,7 @@ cd /var/lib/grafana/dashboards
 
 ####### BUILD THE DASHBOARDS #######
 echo $JSON_DASHBOARDS | jq .[] -c > dashboards
-cat dashboards | while read line
+cat dashboards | while read -r line
 do
   count=$((count + 1))
   echo $line > "dashboard_$count.json"


### PR DESCRIPTION
Add's the `-r` flag to read in order to preserve escaped characters (e.g. `\"`) in the `$JSON_DASHOARDS`. Without this the JSON can be rendered invalid.